### PR TITLE
Allow reload of lsyncd config independent of slave change check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ config.php
 vendor/
 data/
 test.php
+# PHP Storm
+.idea

--- a/reload_config.php
+++ b/reload_config.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file A simple script to force re-generation of the lsyncd config file because of a change
+ * in the original Lua template/app configuration.
+ */
+
+require 'config.php';
+require 'utilities.php';
+require 'vendor/autoload.php';
+
+// As we use the longopts parameter of getopt() which was only introduced in
+// PHP 5.3.0, lets make sure the environment is okay first.
+if (version_compare(phpversion(), '5.3.0') < 0) {
+  die('You need to have at least PHP 5.3.0 to run this script.');
+}
+
+reloadConfig($APP_CONF, $LSYNCD_CONF, $AWS_CONF);
+echo "New configuration file generated at " . $APP_CONF['data_dir'] . "lsyncd.conf.lua\n";
+
+$options = getopt('', array('restart'));
+if (isset($options['restart'])) {
+  echo "Restart Lsyncd\n";
+  restartLsyncd($APP_CONF);
+}

--- a/utilities.php
+++ b/utilities.php
@@ -13,22 +13,45 @@
 use Liip\ProcessManager\ProcessManager;
 
 /**
- * Check if slaves fingerprint has changed
+ * Gets the list of slaves previously recorded.
+ *
+ * @param string $fileLocation Location of file storing slaves configuration
+ * @return array
+ */
+function getSlaves($fileLocation)
+{
+  $old = array();
+  if (file_exists($fileLocation)) {
+    $old = unserialize(file_get_contents($fileLocation));
+  }
+  return $old;
+}
+
+/**
+ * Records a list of slaves.
+ *
+ * @param array $slaves A list of slave identifiers
+ * @param string $fileLocation Location of file storing slaves configuration
+ */
+function setSlaves(array $slaves, $fileLocation) {
+  if (!is_writable($fileLocation)) {
+    trigger_error($fileLocation . ' is not writable.', E_USER_ERROR);
+  }
+  file_put_contents($fileLocation, serialize($slaves));
+}
+
+/**
+ * Check if the slaves fingerprint has changed.
  *
  * @param array $slaves Array of slaves with EC2 instance ID as array key
  * @param string $fileLocation Location of file storing slaves configuration
+ * @see getSlaves().
+ * @see setSlaves().
  * @return boolean
  */
 function hasSlavesChanged($slaves, $fileLocation) 
 {
-    $old = array();
-    if (file_exists($fileLocation)) {
-        $old = unserialize(file_get_contents($fileLocation));
-        
-        if (!is_writable($fileLocation)) {
-            trigger_error($fileLocation . ' is not writable.', E_USER_ERROR);
-        }
-    }
+    $old = getSlaves($fileLocation);
     
     sort($old);
     sort($slaves);
@@ -37,7 +60,8 @@ function hasSlavesChanged($slaves, $fileLocation)
         return false;
     }
 
-    file_put_contents($fileLocation, serialize($slaves));
+    setSlaves($slaves, $fileLocation);
+
     return true;
 }
 
@@ -103,4 +127,62 @@ function startLsyncd($APP_CONF)
     echo "Lsyncd started. Pid: $pid.\n";
 
     return;
+}
+
+/**
+ * Regenerates the lsyncd config file based on the template and app config.
+ *
+ * @param array $APP_CONF Associative array used for configuring the app
+ * @param array $LSYNCD_CONF Associative array used for configuring the lsync daemon
+ * @param array $AWS_CONF Associative array having AWS config.
+ * @param mixed $slaveIDs A list of slave identifiers. Defaults to NULL.
+ *
+ * @throws Exception when instance information cannot be fetched from AWS.
+ *
+ * @todo Move this API method elsewhere. utilities is probably not the best place for
+ * it considering its strong dependency on the application itself.
+ */
+function reloadConfig($APP_CONF, $LSYNCD_CONF, $AWS_CONF, $slaveIDs = NULL)
+{
+  $slaves = array();
+  if (!isset($slaveIDs)) {
+    $slaveIDs = getSlaves($APP_CONF['data_dir'] . 'slaves');
+  }
+
+  require_once 'vendor/autoload.php';
+
+  // Initialize the AWS client and query for meta information about the
+  // slave identifiers at hand.
+  $aws = Aws\Common\Aws::factory(array(
+    'key' => $AWS_CONF['key'],
+    'secret' => $AWS_CONF['secret'],
+    'region' => $AWS_CONF['region']
+  ));
+  $ec2Client = $aws->get('Ec2');
+  $ec2Instances = $ec2Client->describeInstances(array('InstanceIds' => $slaveIDs));
+  if (empty($ec2Instances)) {
+    throw new Exception('Unable to obtain description of slave EC2 instances.');
+  }
+  foreach ($ec2Instances['Reservations'] as $reservation) {
+    $instances = $reservation['Instances'];
+
+    foreach ($instances as $instance) {
+      $slaves[] = array(
+        'instance_id' => $instance['InstanceId'],
+        'private_ip_address' => $instance['PrivateIpAddress']
+      );
+    }
+  }
+
+  $mustache = new Mustache_Engine;
+  $data = array(
+    'app' => array(
+      'generation_time' => date('r')
+    ),
+    'lsyncd' => $LSYNCD_CONF,
+    'slaves' => $slaves
+  );
+
+  $lsyncdConf = $mustache->render(file_get_contents($APP_CONF['lsyncd_conf_template']), $data);
+  file_put_contents($APP_CONF['data_dir'] . 'lsyncd.conf.lua', $lsyncdConf);
 }


### PR DESCRIPTION
Right now, a new lsyncd config - `lsyncd.conf.lua` is generated only when new slaves have been added/removed from the load balancer. However, it is possible that there is a change in the original config template - `lsyncd.conf.lua.template` itself or a change in the values for certain parameters in the `config.php` file (app config) in which case we may want to do a lsyncd config reload independently.

This pull request adds a new file `reload_config.php` (open to a better name) that can be used for this purpose.

```
# Generates a new data/lsyncd.conf.lua file 
php reload_config.php
# Generates a new lsyncd conf file & restarts the daemon
php reload_config.php --restart
```

Have also refactored out three methods in `utilities.php`:

```
getSlaves()
setSlaves()
reloadConfig()
```
